### PR TITLE
chore: fix resolver image workflow

### DIFF
--- a/.github/workflows/resolver_image.yml
+++ b/.github/workflows/resolver_image.yml
@@ -38,6 +38,16 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Go
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Build
+        run: make build
+
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.


### PR DESCRIPTION
Runs ` make build` before resolver image build step. This wasn't done initially because it used the `images/` context which has since been deleted for simplicity.