### PR TITLE
chore: migrate reference contract to Algorand TypeScript 1.0

### DIFF
--- a/reference_contract/contracts/artifacts/DIDAlgoStorage.arc56.json
+++ b/reference_contract/contracts/artifacts/DIDAlgoStorage.arc56.json
@@ -3217,9 +3217,9 @@
     "compiler": "algod",
     "compilerVersion": {
       "major": 4,
-      "minor": 2,
+      "minor": 4,
       "patch": 1,
-      "commitHash": "a9c634f1"
+      "commitHash": "7b607ce4"
     }
   }
 }

--- a/reference_contract/contracts/did-algo-storage.algo.ts
+++ b/reference_contract/contracts/did-algo-storage.algo.ts
@@ -1,5 +1,17 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Contract } from '@algorandfoundation/tealscript';
+import {
+  Contract,
+  uint64,
+  bytes,
+  BoxMap,
+  GlobalState,
+  Account,
+  Global,
+  Txn,
+  assert,
+  itxn,
+  gtxn,
+  clone,
+} from '@algorandfoundation/algorand-typescript';
 
 /** Metadata about DID Document data */
 type Metadata = {
@@ -10,7 +22,7 @@ type Metadata = {
   end: uint64,
 
   /** status - 0 if uploading, 1 if ready, 2 if deleting */
-  status: uint<8>,
+  status: uint64,
 
   /** The size of the last box */
   endSize: uint64,
@@ -23,27 +35,23 @@ type Metadata = {
 };
 
 /** Indicates the data is still being uploaded */
-const UPLOADING = <uint<8>>0;
+const UPLOADING = 0;
+const READY = 1;
+const DELETING = 2;
 
-/** Indicates the data is done uploading and can be safely read */
-const READY = <uint<8>>1;
-
-/** Indicates the data is currently being deleted */
-const DELETING = <uint<8>>2;
-
-const COST_PER_BYTE = 400;
-const COST_PER_BOX = 2500;
-const MAX_BOX_SIZE = 32768;
+const COST_PER_BYTE: uint64 = 400;
+const COST_PER_BOX: uint64 = 2500;
+const MAX_BOX_SIZE: uint64 = 32768;
 
 export class DIDAlgoStorage extends Contract {
   /** The boxes that contain the data, indexed by uint64 */
-  dataBoxes = BoxMap<uint64, bytes>();
+  dataBoxes = BoxMap<uint64, bytes>({ keyPrefix: 'd' });
 
   /** Metadata for a given pubkey */
-  metadata = BoxMap<Address, Metadata>();
+  metadata = BoxMap<Account, Metadata>({ keyPrefix: 'm' });
 
   /** The index of the next box to be created */
-  currentIndex = GlobalStateKey<uint64>();
+  currentIndex = GlobalState<uint64>();
 
   /**
    *
@@ -55,15 +63,15 @@ export class DIDAlgoStorage extends Contract {
    * @param mbrPayment Payment from the uploader to cover the box MBR
    */
   startUpload(
-    pubKey: Address,
+    pubKey: Account,
     numBoxes: uint64,
     endBoxSize: uint64,
-    mbrPayment: PayTxn,
+    mbrPayment: gtxn.PaymentTxn,
   ): void {
-    assert(this.txn.sender === globals.creatorAddress);
+    assert(Txn.sender === Global.creatorAddress);
 
     const startBox = this.currentIndex.value;
-    const endBox = startBox + numBoxes - 1;
+    const endBox: uint64 = (startBox + numBoxes - 1) as uint64;
 
     const metadata: Metadata = {
       start: startBox, end: endBox, status: UPLOADING, endSize: endBoxSize, lastDeleted: 0,
@@ -71,18 +79,18 @@ export class DIDAlgoStorage extends Contract {
 
     assert(!this.metadata(pubKey).exists);
 
-    this.metadata(pubKey).value = metadata;
+    this.metadata(pubKey).value = clone(metadata);
 
-    this.currentIndex.value = endBox + 1;
+    this.currentIndex.value = (endBox + 1) as uint64;
 
-    const totalCost = numBoxes * COST_PER_BOX // cost of data boxes
-    + (numBoxes - 1) * MAX_BOX_SIZE * COST_PER_BYTE // cost of data
-    + numBoxes * 8 * COST_PER_BYTE // cost of data keys
-    + endBoxSize * COST_PER_BYTE // cost of last data box
-    + COST_PER_BOX + (8 + 8 + 1 + 8 + 32 + 8) * COST_PER_BYTE; // cost of metadata box
+    const totalCost: uint64 = (numBoxes * COST_PER_BOX) // cost of data boxes
+      + ((numBoxes - 1) * MAX_BOX_SIZE * COST_PER_BYTE) // cost of data
+      + (numBoxes * 8 * COST_PER_BYTE) // cost of data keys
+      + (endBoxSize * COST_PER_BYTE) // cost of last data box
+      + COST_PER_BOX + ((8 + 8 + 1 + 8 + 32 + 8) * COST_PER_BYTE); // cost of metadata box
 
     assert(mbrPayment.amount === totalCost);
-    assert(mbrPayment.receiver === this.app.address);
+    assert(mbrPayment.receiver === Global.currentApplicationAddress);
   }
 
   /**
@@ -94,15 +102,15 @@ export class DIDAlgoStorage extends Contract {
    * @param offset The offset within the box to start writing the data
    * @param data The data to write
    */
-  upload(pubKey: Address, boxIndex: uint64, offset: uint64, data: bytes): void {
-    assert(this.txn.sender === globals.creatorAddress);
+  upload(pubKey: Account, boxIndex: uint64, offset: uint64, data: bytes): void {
+    assert(Txn.sender === Global.creatorAddress);
 
-    const metadata = this.metadata(pubKey).value;
+    const metadata = clone(this.metadata(pubKey).value);
     assert(metadata.status === UPLOADING);
     assert(metadata.start <= boxIndex && boxIndex <= metadata.end);
 
     if (offset === 0) {
-      this.dataBoxes(boxIndex).create(boxIndex === metadata.end ? metadata.endSize : MAX_BOX_SIZE);
+      this.dataBoxes(boxIndex).create({ size: boxIndex === metadata.end ? metadata.endSize : MAX_BOX_SIZE });
     }
 
     this.dataBoxes(boxIndex).replace(offset, data);
@@ -114,8 +122,8 @@ export class DIDAlgoStorage extends Contract {
    *
    * @param pubKey The address of the DID
    */
-  finishUpload(pubKey: Address): void {
-    assert(this.txn.sender === globals.creatorAddress);
+  finishUpload(pubKey: Account): void {
+    assert(Txn.sender === Global.creatorAddress);
 
     this.metadata(pubKey).value.status = READY;
   }
@@ -125,10 +133,10 @@ export class DIDAlgoStorage extends Contract {
    *
    * @param pubKey The address of the DID
    */
-  startDelete(pubKey: Address): void {
-    assert(this.txn.sender === globals.creatorAddress);
+  startDelete(pubKey: Account): void {
+    assert(Txn.sender === Global.creatorAddress);
 
-    const metadata = this.metadata(pubKey).value;
+    const metadata = clone(this.metadata(pubKey).value);
     assert(metadata.status === READY);
 
     metadata.status = DELETING;
@@ -140,33 +148,33 @@ export class DIDAlgoStorage extends Contract {
    * @param pubKey The address of the DID
    * @param boxIndex The index of the box to delete
    */
-  deleteData(pubKey: Address, boxIndex: uint64): void {
-    assert(this.txn.sender === globals.creatorAddress);
+  deleteData(pubKey: Account, boxIndex: uint64): void {
+    assert(Txn.sender === Global.creatorAddress);
 
-    const metadata = this.metadata(pubKey).value;
+    const metadata = clone(this.metadata(pubKey).value);
     assert(metadata.status === DELETING);
     assert(metadata.start <= boxIndex && boxIndex <= metadata.end);
 
     if (boxIndex !== metadata.start) assert(metadata.lastDeleted === boxIndex - 1);
 
-    const preMBR = globals.currentApplicationAddress.minBalance;
+    const preMBR = Global.currentApplicationAddress.minBalance;
 
     this.dataBoxes(boxIndex).delete();
 
     if (boxIndex === metadata.end) this.metadata(pubKey).delete();
     else metadata.lastDeleted = boxIndex;
 
-    sendPayment({
-      amount: preMBR - globals.currentApplicationAddress.minBalance,
-      receiver: this.txn.sender,
-    });
+    itxn.payment({
+      amount: preMBR - Global.currentApplicationAddress.minBalance,
+      receiver: Txn.sender,
+    }).submit();
   }
 
   /**
    * Allow the contract to be updated by the creator
    */
   updateApplication(): void {
-    assert(this.txn.sender === globals.creatorAddress);
+    assert(Txn.sender === Global.creatorAddress);
   }
 
   /**
@@ -175,5 +183,5 @@ export class DIDAlgoStorage extends Contract {
    * at a time. Thus when a box is deleted, we need to add additional dummy calls with box
    * references to increase the total read/write budget to 32k.
    */
-  dummy(): void {}
+  dummy(): void { }
 }


### PR DESCRIPTION
- Migrate from TEALScript to Algorand TypeScript 1.0
- Update imports and type annotations
- Add clone() for metadata assignments
- Update BoxMap with keyPrefix
- Replace sendPayment with itxn.payment()
